### PR TITLE
Switch backend to FastAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ frontend provides a simple chat interface with example prompts and a message his
 
 - **Conversational querying** – ask questions about the movie dataset in plain
   language.  Gemini generates the SQL and the backend runs it on MySQL.
-- **Stream or batch replies** – the Flask API supports both regular JSON
+- **Stream or batch replies** – the FastAPI backend supports both regular JSON
   responses and optional streaming.
 - **Example prompts & history** – the React client includes sample queries,
   keeps chat history in memory and lets you clear it with a confirmation dialog.
@@ -19,7 +19,7 @@ frontend provides a simple chat interface with example prompts and a message his
 ## Project layout
 
 ```
-backend/    # Flask server and Gemini integration
+backend/    # FastAPI server and Gemini integration
 frontend/   # React client (TypeScript)
 db/         # SQL scripts used to load the IMDb dataset
 docker-compose.yml  # spins up the MySQL service
@@ -27,7 +27,7 @@ docker-compose.yml  # spins up the MySQL service
 
 ### Backend
 
-The Flask app exposes the following endpoints:
+The FastAPI app exposes the following endpoints:
 
 - `POST /api/chat` – send a user message and get the assistant reply
 - `POST /api/chat/stream` – same as above but returned as a server-sent event stream
@@ -83,7 +83,7 @@ backend running on port 8000.
 
 4. **Run the backend**
    ```bash
-   python backend/start_server.py
+   uvicorn backend.fastapi_backend:app --host 0.0.0.0 --port 8000
    ```
 
 5. **Run the frontend** (in another terminal):

--- a/backend/fastapi_backend.py
+++ b/backend/fastapi_backend.py
@@ -1,15 +1,93 @@
-from typing import Union
+"""FastAPI version of the MovieGPT backend."""
 
-from fastapi import FastAPI
+from __future__ import annotations
+
+import json
+import logging
+from typing import AsyncGenerator
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from Schema import chat, chat_history
+
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
 
 app = FastAPI()
 
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
-@app.get("/")
-def read_root():
-    return {"hello": "world"}
+
+@app.post("/api/chat")
+async def api_chat(payload: dict) -> JSONResponse:
+    """Return a single assistant response."""
+    user_message = payload.get("message")
+    if not user_message:
+        raise HTTPException(status_code=400, detail="缺少message参数")
+
+    logger.info("收到用户消息: %s", user_message)
+    ai_response = chat(user_message)
+    logger.info("AI回复: %s", ai_response)
+
+    return JSONResponse({"text": ai_response, "sql": None, "data": None})
 
 
-@app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
-    return {"item_id": item_id, "q": q}
+@app.post("/api/chat/stream")
+async def api_chat_stream(payload: dict) -> StreamingResponse:
+    """Stream tokens one by one in a Server-Sent Events format."""
+    user_message = payload.get("message")
+    if not user_message:
+        raise HTTPException(status_code=400, detail="缺少message参数")
+
+    async def generator() -> AsyncGenerator[str, None]:
+        ai_response = chat(user_message)
+        for i, char in enumerate(ai_response):
+            chunk = json.dumps({"token": char, "complete": i == len(ai_response) - 1}, ensure_ascii=False)
+            yield f"data: {chunk}\n\n"
+
+        final = json.dumps({"complete": True, "text": ai_response}, ensure_ascii=False)
+        yield f"data: {final}\n\n"
+        yield "data: [DONE]\n\n"
+
+    return StreamingResponse(generator(), media_type="text/plain")
+
+
+@app.get("/api/history")
+async def get_chat_history() -> JSONResponse:
+    """Return stored conversation history."""
+    history = []
+    for content in chat_history:
+        if hasattr(content, "role") and hasattr(content, "parts"):
+            role = "user" if content.role == "user" else "assistant"
+            text = content.parts[0].text if content.parts else ""
+            history.append({"id": f"{len(history)}", "type": role, "text": text, "timestamp": 0})
+
+    return JSONResponse({"history": history})
+
+
+@app.post("/api/clear")
+async def clear_history() -> JSONResponse:
+    """Clear the conversation history."""
+    chat_history.clear()
+    return JSONResponse({"message": "历史记录已清除"})
+
+
+@app.get("/health")
+async def health_check() -> JSONResponse:
+    """Simple health check used by the frontend."""
+    return JSONResponse({"status": "healthy", "service": "MovieGPT API"})
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("fastapi_backend:app", host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- implement FastAPI server under `backend/fastapi_backend.py`
- document FastAPI endpoints and usage in README

## Testing
- `python -m py_compile backend/fastapi_backend.py backend/Schema.py backend/app.py backend/start_server.py backend/simple_app.py`
- `npm test --prefix frontend/moviegpt-react` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ce6df49188331ab1265704610808c