### PR TITLE
Update brand to 404Found

### DIFF
--- a/frontend/moviegpt-react/public/index.html
+++ b/frontend/moviegpt-react/public/index.html
@@ -10,7 +10,7 @@
       content="MovieGPT - 404Found"
     />
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
-    <title>MovieGPT - 404NotFound</title>
+    <title>MovieGPT - 404Found</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/moviegpt-react/src/App.test.tsx
+++ b/frontend/moviegpt-react/src/App.test.tsx
@@ -8,8 +8,8 @@ test('renders MovieGPT title', () => {
   expect(titleElement).toBeInTheDocument();
 });
 
-test('renders welcome text', () => {
+test('renders brand text', () => {
   render(<App />);
-  const welcomeElement = screen.getByText(/hello/i);
-  expect(welcomeElement).toBeInTheDocument();
-}); 
+  const brandElement = screen.getByText(/404Found/i);
+  expect(brandElement).toBeInTheDocument();
+});

--- a/frontend/moviegpt-react/src/components/Header.tsx
+++ b/frontend/moviegpt-react/src/components/Header.tsx
@@ -9,7 +9,7 @@ const Header: React.FC<HeaderProps> = ({ isCompact }) => {
   return (
     <div className={`${styles.header} ${isCompact ? styles.headerCompact : ''}`}>
       <div className={`${styles.logo} ${isCompact ? styles.logoCompact : ''}`}>MovieGPT</div>
-      {!isCompact && <div className={styles.brand}>404NotFound</div>}
+      {!isCompact && <div className={styles.brand}>404Found</div>}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- display project name as **404Found** instead of **404NotFound**
- update header brand name and page title
- adjust React test accordingly

## Testing
- `npm test -- --watchAll=false --ci`

------
https://chatgpt.com/codex/tasks/task_e_685d6857076c83319ea28c2f1707f655