### PR TITLE
Expose SQL results and OMDb info

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The FastAPI app exposes the following endpoints:
 
 - `POST /api/chat` – send a user message and get the assistant reply
 - `POST /api/chat/stream` – same as above but returned as a server-sent event stream
+- `GET  /api/info/{imdb_id}` – fetch additional movie info from OMDb by IMDb ID
 - `GET  /api/history` – retrieve conversation history
 - `POST /api/clear` – clear the stored history
 - `GET  /health` – health check used by the frontend

--- a/frontend/moviegpt-react/src/services/apiService.ts
+++ b/frontend/moviegpt-react/src/services/apiService.ts
@@ -11,6 +11,27 @@ export interface APIResponse {
   error?: string;
 }
 
+// OMDb movie info
+export const getMovieInfo = async (imdbId: string): Promise<any> => {
+  try {
+    const response = await fetch(`${API_BASE_URL}/api/info/${imdbId}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error('获取影片信息失败:', error);
+    return null;
+  }
+};
+
 // 调用后端的chat接口
 export const callLLMAPI = async (userInput: string): Promise<APIResponse> => {
   try {


### PR DESCRIPTION
## Summary
- return last SQL query and rows in `chat`
- include SQL result details in `/api/chat` and streaming responses
- expose `/api/info/{imdb_id}` endpoint and front-end helper
- document new endpoint in README

## Testing
- `python -m py_compile backend/Schema.py backend/get_info.py backend/fastapi_backend.py`
- `pyright` *(fails: missing modules)*
- `npm run build` *(fails: react-scripts not found)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d6ef1cbb0833197320bd5ade649da