### PR TITLE
Fix SQL result handling

### DIFF
--- a/backend/fastapi_backend.py
+++ b/backend/fastapi_backend.py
@@ -36,10 +36,10 @@ async def api_chat(payload: dict) -> JSONResponse:
         raise HTTPException(status_code=400, detail="缺少message参数")
 
     logger.info("收到用户消息: %s", user_message)
-    text, sql, data = chat(user_message)
+    text, sql, data, results = chat(user_message)
     logger.info("AI回复: %s", text)
 
-    return JSONResponse({"text": text, "sql": sql, "data": data})
+    return JSONResponse({"text": text, "sql": sql, "data": data, "results": results})
 
 
 @app.post("/api/chat/stream")
@@ -50,7 +50,7 @@ async def api_chat_stream(payload: dict) -> StreamingResponse:
         raise HTTPException(status_code=400, detail="缺少message参数")
 
     async def generator() -> AsyncGenerator[str, None]:
-        text, sql, data = chat(user_message)
+        text, sql, data, results = chat(user_message)
         for i, char in enumerate(text):
             chunk = json.dumps(
                 {"token": char, "complete": i == len(text) - 1},
@@ -58,7 +58,7 @@ async def api_chat_stream(payload: dict) -> StreamingResponse:
             )
             yield f"data: {chunk}\n\n"
 
-        final = json.dumps({"complete": True, "text": text, "sql": sql, "data": data}, ensure_ascii=False)
+        final = json.dumps({"complete": True, "text": text, "sql": sql, "data": data, "results": results}, ensure_ascii=False)
         yield f"data: {final}\n\n"
         yield "data: [DONE]\n\n"
 

--- a/frontend/moviegpt-react/src/App.tsx
+++ b/frontend/moviegpt-react/src/App.tsx
@@ -43,13 +43,14 @@ const App: React.FC = () => {
     return () => clearInterval(healthCheckInterval);
   }, []);
 
-  const addMessage = useCallback((type: 'user' | 'assistant', text: string, sql?: string, data?: string) => {
+  const addMessage = useCallback((type: 'user' | 'assistant', text: string, sql?: string, data?: any, results?: any[]) => {
     const newMessage: Message = {
       id: generateId(),
       type,
       text,
       sql,
       data,
+      results,
       timestamp: Date.now()
     };
     setMessages(prev => [...prev, newMessage]);
@@ -82,7 +83,7 @@ const App: React.FC = () => {
         addMessage('assistant', response.text);
       } else {
         // 添加AI回复
-        addMessage('assistant', response.text, response.sql, response.data);
+        addMessage('assistant', response.text, response.sql, response.data, response.results);
       }
     } catch (error) {
       // 处理API调用异常

--- a/frontend/moviegpt-react/src/components/Message.tsx
+++ b/frontend/moviegpt-react/src/components/Message.tsx
@@ -9,7 +9,7 @@ interface MessageProps {
 }
 
 const Message: React.FC<MessageProps> = ({ message }) => {
-  const { type, text, sql, data } = message;
+  const { type, text, sql, data, results } = message;
   const avatarIcon = type === 'user' ? 'fa-user' : 'fa-robot';
 
   return (
@@ -21,14 +21,29 @@ const Message: React.FC<MessageProps> = ({ message }) => {
         <div className={styles.messageBubble}>
           <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
         </div>
-        {sql && data && (
+        {results && results.length > 0 ? (
           <div className={styles.sqlResult}>
-            <div 
-              className={styles.sqlQuery}
-              dangerouslySetInnerHTML={{ __html: sql }}
-            />
-            <div dangerouslySetInnerHTML={{ __html: data }} />
+            {results.map((r, idx) => (
+              <div key={idx} className={styles.sqlBlock}>
+                {r.sql && (
+                  <div className={styles.sqlQuery}>
+                    <code>{r.sql}</code>
+                  </div>
+                )}
+                {r.rows && (
+                  <pre>{JSON.stringify(r.rows, null, 2)}</pre>
+                )}
+                {r.error && <pre>{r.error}</pre>}
+              </div>
+            ))}
           </div>
+        ) : (
+          sql && data && (
+            <div className={styles.sqlResult}>
+              <div className={styles.sqlQuery} dangerouslySetInnerHTML={{ __html: sql }} />
+              <div dangerouslySetInnerHTML={{ __html: data }} />
+            </div>
+          )
         )}
       </div>
     </div>

--- a/frontend/moviegpt-react/src/services/apiService.ts
+++ b/frontend/moviegpt-react/src/services/apiService.ts
@@ -7,7 +7,8 @@ const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:800
 export interface APIResponse {
   text: string;
   sql?: string;
-  data?: string;
+  data?: any;
+  results?: any[];
   error?: string;
 }
 
@@ -48,11 +49,12 @@ export const callLLMAPI = async (userInput: string): Promise<APIResponse> => {
     }
 
     const data = await response.json();
-    
+
     return {
       text: data.text || '抱歉，我无法理解您的问题。',
       sql: data.sql,
       data: data.data,
+      results: data.results,
       error: data.error,
     };
   } catch (error) {
@@ -171,7 +173,8 @@ export const callLLMAPIStream = async (
               onComplete({
                 text: parsed.text || '',
                 sql: parsed.sql,
-                data: parsed.data
+                data: parsed.data,
+                results: parsed.results
               });
               return;
             }

--- a/frontend/moviegpt-react/src/styles/Message.module.css
+++ b/frontend/moviegpt-react/src/styles/Message.module.css
@@ -63,6 +63,10 @@
   font-size: 12px;
 }
 
+.sqlBlock {
+  margin-bottom: 12px;
+}
+
 .sqlQuery {
   background: #2d2d2d;
   color: #f0f0f0;

--- a/frontend/moviegpt-react/src/types/index.ts
+++ b/frontend/moviegpt-react/src/types/index.ts
@@ -3,7 +3,8 @@ export interface Message {
   type: 'user' | 'assistant';
   text: string;
   sql?: string;
-  data?: string;
+  data?: any;
+  results?: any[];
   timestamp: number;
 }
 
@@ -23,7 +24,8 @@ export interface ChatRequest {
 export interface ChatResponse {
   text: string;
   sql?: string;
-  data?: string;
+  data?: any;
+  results?: any[];
   error?: string;
   conversationId?: string;
 }


### PR DESCRIPTION
## Summary
- convert mysql rows to plain dicts for JSON serialization
- collect all SQL query results in chat helper
- expose collected results via API
- adjust frontend types and components for multiple results

## Testing
- `python -m pytest backend/`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685e0e393c3c833184f06919cb61c1ea