### PR TITLE
Add dark mode

### DIFF
--- a/frontend/moviegpt-react/src/App.tsx
+++ b/frontend/moviegpt-react/src/App.tsx
@@ -20,6 +20,20 @@ const App: React.FC = () => {
   const [isBackendConnected, setIsBackendConnected] = useState(false);
   const [refreshQueries, setRefreshQueries] = useState(false);
   const clearButtonRef = useRef<HTMLButtonElement>(null);
+  const [isDarkMode, setIsDarkMode] = useState(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored) return stored === 'dark';
+    return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  });
+
+  useEffect(() => {
+    document.body.classList.toggle('dark', isDarkMode);
+    localStorage.setItem('theme', isDarkMode ? 'dark' : 'light');
+  }, [isDarkMode]);
+
+  const toggleDarkMode = useCallback(() => {
+    setIsDarkMode(prev => !prev);
+  }, []);
 
   // 检查后端连接状态
   useEffect(() => {
@@ -131,7 +145,11 @@ const App: React.FC = () => {
 
   return (
     <div className={styles.app}>
-      <Header isCompact={hasStartedConversation} />
+      <Header
+        isCompact={hasStartedConversation}
+        isDarkMode={isDarkMode}
+        onToggleDarkMode={toggleDarkMode}
+      />
       
       <div className={styles.mainContainer}>
         <WelcomeText shouldHide={shouldHideWelcome} />

--- a/frontend/moviegpt-react/src/components/Header.tsx
+++ b/frontend/moviegpt-react/src/components/Header.tsx
@@ -3,13 +3,18 @@ import styles from '../styles/App.module.css';
 
 interface HeaderProps {
   isCompact: boolean;
+  isDarkMode: boolean;
+  onToggleDarkMode: () => void;
 }
 
-const Header: React.FC<HeaderProps> = ({ isCompact }) => {
+const Header: React.FC<HeaderProps> = ({ isCompact, isDarkMode, onToggleDarkMode }) => {
   return (
     <div className={`${styles.header} ${isCompact ? styles.headerCompact : ''}`}>
       <div className={`${styles.logo} ${isCompact ? styles.logoCompact : ''}`}>MovieGPT</div>
       {!isCompact && <div className={styles.brand}>404Found</div>}
+      <button className={styles.themeToggle} onClick={onToggleDarkMode} title="切换主题">
+        {isDarkMode ? '☀️' : '🌙'}
+      </button>
     </div>
   );
 };

--- a/frontend/moviegpt-react/src/index.css
+++ b/frontend/moviegpt-react/src/index.css
@@ -5,12 +5,34 @@
   box-sizing: border-box;
 }
 
+:root {
+  --bg-color: #fafafa;
+  --text-color: #333;
+  --secondary-text-color: #666;
+  --border-color: #e5e5e5;
+  --accent-bg: #f5f5f5;
+  --accent-text: #333;
+  --button-bg: #333;
+  --button-hover-bg: #555;
+}
+
+body.dark {
+  --bg-color: #1f1f1f;
+  --text-color: #ddd;
+  --secondary-text-color: #aaa;
+  --border-color: #444;
+  --accent-bg: #2d2d2d;
+  --accent-text: #eee;
+  --button-bg: #666;
+  --button-hover-bg: #888;
+}
+
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background: #fafafa;
-  color: #333;
+  background: var(--bg-color);
+  color: var(--text-color);
   height: 100vh;
   overflow: hidden;
 }

--- a/frontend/moviegpt-react/src/styles/App.module.css
+++ b/frontend/moviegpt-react/src/styles/App.module.css
@@ -10,7 +10,7 @@
 .header {
   padding: 20px 0;
   text-align: center;
-  border-bottom: 1px solid #e5e5e5;
+  border-bottom: 1px solid var(--border-color);
   position: relative;
   flex-shrink: 0;
   transition: all 0.6s cubic-bezier(0.4, 0, 0.2, 1);
@@ -20,7 +20,7 @@
   padding: 12px 20px;
   text-align: left;
   border-bottom: 1px solid transparent;
-  background: rgba(250, 250, 250, 0.95);
+  background: var(--bg-color);
   backdrop-filter: blur(10px);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
@@ -28,7 +28,7 @@
 .logo {
   font-size: 24px;
   font-weight: 700;
-  color: #000;
+  color: var(--text-color);
   margin-bottom: 4px;
   transition: all 0.6s cubic-bezier(0.4, 0, 0.2, 1);
 }
@@ -36,7 +36,7 @@
 .logoCompact {
   font-size: 18px;
   font-weight: 600;
-  color: #666;
+  color: var(--secondary-text-color);
   margin-bottom: 0;
   opacity: 0.8;
 }
@@ -44,12 +44,23 @@
 .brand {
   position: absolute;
   top: 20px;
-  right: 20px;
+  right: 60px;
   font-size: 12px;
-  color: #999;
+  color: var(--secondary-text-color);
   font-weight: 500;
   opacity: 0.6;
   transition: opacity 0.4s ease;
+}
+
+.themeToggle {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 16px;
+  color: var(--text-color);
 }
 
 
@@ -131,8 +142,8 @@
   transform: translateX(-50%);
   width: 100%;
   max-width: 800px;
-  background: #fafafa;
-  border-top: 1px solid #e5e5e5;
+  background: var(--bg-color);
+  border-top: 1px solid var(--border-color);
   padding: 0 20px;
   z-index: 10; /* 确保底部区域在背景logo之上 */
 }
@@ -148,21 +159,21 @@
 }
 
 .exampleQuery {
-  background: #f5f5f5;
-  border: 1px solid #e0e0e0;
+  background: var(--accent-bg);
+  border: 1px solid var(--border-color);
   border-radius: 20px;
   padding: 8px 16px;
   cursor: pointer;
   transition: all 0.2s ease;
   font-size: 13px;
-  color: #666;
+  color: var(--secondary-text-color);
   white-space: nowrap;
 }
 
 .exampleQuery:hover {
-  background: #eee;
-  border-color: #ccc;
-  color: #333;
+  background: var(--accent-bg);
+  border-color: var(--border-color);
+  color: var(--text-color);
 }
 
 .inputArea {
@@ -177,8 +188,8 @@
   height: 52px !important;
   border: none !important;
   border-radius: 50% !important;
-  background: #f5f5f5 !important;
-  color: #666 !important;
+  background: var(--accent-bg) !important;
+  color: var(--secondary-text-color) !important;
   cursor: pointer;
   display: flex !important;
   align-items: center !important;
@@ -191,7 +202,7 @@
 }
 
 .clearButton:hover {
-  background: #eee !important;
+  background: var(--accent-bg) !important;
 }
 
 .clearButton:active {
@@ -203,8 +214,8 @@
   display: flex;
   gap: 12px;
   align-items: flex-end;
-  background: white;
-  border: 1px solid #ddd;
+  background: var(--bg-color);
+  border: 1px solid var(--border-color);
   border-radius: 24px;
   padding: 8px 12px;
   transition: all 0.2s ease;
@@ -212,7 +223,7 @@
 }
 
 .inputContainer:focus-within {
-  border-color: #999;
+  border-color: var(--secondary-text-color);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
@@ -231,7 +242,7 @@
 }
 
 .inputTextarea::placeholder {
-  color: #aaa;
+  color: var(--secondary-text-color);
 }
 
 .sendButton {
@@ -239,7 +250,7 @@
   height: 32px;
   border: none;
   border-radius: 50%;
-  background: #333;
+  background: var(--button-bg);
   color: white;
   cursor: pointer;
   display: flex;
@@ -251,7 +262,7 @@
 }
 
 .sendButton:hover {
-  background: #555;
+  background: var(--button-hover-bg);
 }
 
 .sendButton:disabled {
@@ -273,6 +284,10 @@
   z-index: 1;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   letter-spacing: 8px;
+}
+
+:global(body.dark) .welcomeText {
+  color: rgba(255, 255, 255, 0.05);
 }
 
 .welcomeText.hidden {

--- a/frontend/moviegpt-react/src/styles/ConfirmDialog.module.css
+++ b/frontend/moviegpt-react/src/styles/ConfirmDialog.module.css
@@ -11,10 +11,10 @@
 
 .dialog {
   position: absolute;
-  background: white;
+  background: var(--bg-color);
   border-radius: 12px;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--border-color);
   z-index: 10;
   width: 260px;
   animation: dialogFadeIn 0.2s cubic-bezier(0.4, 0, 0.2, 1);
@@ -29,7 +29,7 @@
   transform: translateX(-50%);
   width: 12px;
   height: 12px;
-  background: white;
+  background: var(--bg-color);
   border: 1px solid rgba(0, 0, 0, 0.08);
   border-top: none;
   border-left: none;
@@ -65,7 +65,7 @@
 .title {
   font-size: 14px;
   font-weight: 600;
-  color: #1f2937;
+  color: var(--text-color);
   margin-bottom: 4px;
   line-height: 1.3;
   white-space: nowrap;
@@ -73,7 +73,7 @@
 
 .description {
   font-size: 12px;
-  color: #6b7280;
+  color: var(--secondary-text-color);
   line-height: 1.4;
   word-wrap: break-word;
 }
@@ -83,15 +83,15 @@
   display: flex;
   gap: 8px;
   justify-content: flex-end;
-  border-top: 1px solid #f3f4f6;
+  border-top: 1px solid var(--border-color);
 }
 
 .cancelButton {
   padding: 6px 12px;
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--border-color);
   border-radius: 6px;
-  background: white;
-  color: #6b7280;
+  background: var(--bg-color);
+  color: var(--secondary-text-color);
   font-size: 12px;
   cursor: pointer;
   transition: all 0.15s ease;
@@ -99,9 +99,9 @@
 }
 
 .cancelButton:hover {
-  background: #f9fafb;
-  border-color: #d1d5db;
-  color: #374151;
+  background: var(--accent-bg);
+  border-color: var(--border-color);
+  color: var(--text-color);
 }
 
 .confirmButton {

--- a/frontend/moviegpt-react/src/styles/Message.module.css
+++ b/frontend/moviegpt-react/src/styles/Message.module.css
@@ -21,13 +21,13 @@
 }
 
 .user .messageAvatar {
-  background: #333;
+  background: var(--button-bg);
   color: white;
 }
 
 .assistant .messageAvatar {
-  background: #f0f0f0;
-  color: #666;
+  background: var(--accent-bg);
+  color: var(--secondary-text-color);
 }
 
 .messageContent {
@@ -43,20 +43,20 @@
 }
 
 .user .messageBubble {
-  background: #333;
+  background: var(--button-bg);
   color: white;
   margin-left: auto;
 }
 
 .assistant .messageBubble {
-  background: #f8f8f8;
-  color: #333;
-  border: 1px solid #e5e5e5;
+  background: var(--accent-bg);
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
 }
 
 .sqlResult {
-  background: #fbfbfb;
-  border: 1px solid #e0e0e0;
+  background: var(--bg-color);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   padding: 12px;
   margin-top: 8px;
@@ -82,7 +82,7 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  color: #999;
+  color: var(--secondary-text-color);
   font-size: 13px;
 }
 


### PR DESCRIPTION
## Summary
- add dark mode toggle for frontend
- implement theme switcher in Header component
- style tweaks for dark mode with CSS variables
- adjust message, dialog and general styles for theming

## Testing
- `python -m pytest backend/`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685e1e41b7d08331837d1eeb0e25a0cf