### PR TITLE
Add collapsible SQL result display

### DIFF
--- a/frontend/moviegpt-react/src/components/Message.tsx
+++ b/frontend/moviegpt-react/src/components/Message.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Message as MessageType } from '../types';
+import SQLResultBlock from './SQLResultBlock';
 import styles from '../styles/Message.module.css';
 
 interface MessageProps {
@@ -24,17 +25,7 @@ const Message: React.FC<MessageProps> = ({ message }) => {
         {results && results.length > 0 ? (
           <div className={styles.sqlResult}>
             {results.map((r, idx) => (
-              <div key={idx} className={styles.sqlBlock}>
-                {r.sql && (
-                  <div className={styles.sqlQuery}>
-                    <code>{r.sql}</code>
-                  </div>
-                )}
-                {r.rows && (
-                  <pre>{JSON.stringify(r.rows, null, 2)}</pre>
-                )}
-                {r.error && <pre>{r.error}</pre>}
-              </div>
+              <SQLResultBlock key={idx} result={r} />
             ))}
           </div>
         ) : (

--- a/frontend/moviegpt-react/src/components/SQLResultBlock.tsx
+++ b/frontend/moviegpt-react/src/components/SQLResultBlock.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import styles from '../styles/Message.module.css';
+
+interface Result {
+  sql?: string;
+  rows?: any;
+  error?: string;
+}
+
+interface SQLResultBlockProps {
+  result: Result;
+}
+
+const SQLResultBlock: React.FC<SQLResultBlockProps> = ({ result }) => {
+  const [showFullRows, setShowFullRows] = useState(false);
+
+  const resultString = result.rows ? JSON.stringify(result.rows, null, 2) : '';
+  const lines = resultString.split('\n');
+  const truncated = lines.slice(0, 3).join('\n');
+  const hasMore = lines.length > 3;
+
+  return (
+    <details className={styles.sqlBlock}>
+      <summary className={styles.sqlSummary}>SQL 查询详情</summary>
+      {result.sql && (
+        <div className={styles.sqlQuery}>
+          <code>{result.sql}</code>
+        </div>
+      )}
+      {result.rows && (
+        <div className={styles.sqlRows}>
+          <pre>{showFullRows || !hasMore ? resultString : `${truncated}\n...`}</pre>
+          {hasMore && (
+            <button
+              className={styles.toggleButton}
+              onClick={() => setShowFullRows(!showFullRows)}
+            >
+              {showFullRows ? '折叠' : '展开'}
+            </button>
+          )}
+        </div>
+      )}
+      {result.error && <pre>{result.error}</pre>}
+    </details>
+  );
+};
+
+export default SQLResultBlock;

--- a/frontend/moviegpt-react/src/styles/Message.module.css
+++ b/frontend/moviegpt-react/src/styles/Message.module.css
@@ -67,6 +67,26 @@
   margin-bottom: 12px;
 }
 
+.sqlSummary {
+  cursor: pointer;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.sqlRows {
+  position: relative;
+}
+
+.toggleButton {
+  background: none;
+  border: none;
+  color: #007bff;
+  cursor: pointer;
+  padding: 0;
+  font-size: 12px;
+  margin-top: 4px;
+}
+
 .sqlQuery {
   background: #2d2d2d;
   color: #f0f0f0;


### PR DESCRIPTION
## Summary
- show SQL query details collapsed by default
- truncate SQL rows to three lines and allow expanding
- style toggles in Message module CSS

## Testing
- `npm test --silent`
- `npm run build --silent`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e1f0730e08331b02ceb5529898c50