### PR TITLE
Add GitHub icon to footer link

### DIFF
--- a/frontend/moviegpt-react/src/App.tsx
+++ b/frontend/moviegpt-react/src/App.tsx
@@ -187,6 +187,7 @@ const App: React.FC = () => {
         className={styles.githubLink}
         title="Visit GitHub Repository"
       >
+        <i className="fab fa-github" style={{ marginRight: '4px' }}></i>
         404Found
       </a>
     </div>


### PR DESCRIPTION
## Summary
- add Font Awesome GitHub icon before `404Found` text in the bottom-right link

## Testing
- `python -m pytest backend/`
- `npm test -- --watchAll=false` *(fails: No tests found, exits with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_685e60bb46bc833187934444b5dfb29c