### PR TITLE
Fix chat bubble width

### DIFF
--- a/frontend/moviegpt-react/src/styles/Message.module.css
+++ b/frontend/moviegpt-react/src/styles/Message.module.css
@@ -31,7 +31,6 @@
 }
 
 .messageContent {
-  flex: 1;
   max-width: 70%;
 }
 


### PR DESCRIPTION
## Summary
- adjust `.messageContent` style so chat bubbles resize based on content

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_685e66f850cc83319bab165d82948653