### PR TITLE
Fix movie links for OMDb lookup

### DIFF
--- a/frontend/moviegpt-react/src/components/Message.tsx
+++ b/frontend/moviegpt-react/src/components/Message.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown, { uriTransformer } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Message as MessageType } from '../types';
 import styles from '../styles/Message.module.css';
@@ -99,6 +99,12 @@ const Message: React.FC<MessageProps> = ({ message }) => {
         <div className={styles.messageBubble}>
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}
+            transformLinkUri={(href) => {
+              if (href && href.startsWith('movie:')) {
+                return href;
+              }
+              return uriTransformer(href);
+            }}
             components={{
               a: ({ href, children }) => {
                 if (href && href.startsWith('movie:')) {


### PR DESCRIPTION
## Summary
- allow `movie:` links to bypass ReactMarkdown's URI sanitizer

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff91f8ae08331afcdf60a11ff70c9