### PR TITLE
Improve message list visuals with gradient blur

### DIFF
--- a/frontend/moviegpt-react/src/styles/App.module.css
+++ b/frontend/moviegpt-react/src/styles/App.module.css
@@ -153,12 +153,36 @@
   flex: 1;
   overflow-y: auto;
   padding: 20px 0;
-  margin-bottom: 140px; /* 为底部固定区域留出空间 */
+  margin-bottom: 100px; /* 为底部固定区域留出空间 */
   padding-right: 12px; /* 为滚动条留出更多空间 */
   margin-right: -4px; /* 让滚动条更靠右 */
   transition: padding var(--theme-transition) cubic-bezier(0.4, 0, 0.2, 1);
   position: relative;
   z-index: 1; /* 确保聊天内容在背景logo之上 */
+  scroll-padding-top: 60px; /* 避免顶部消息被 Header 遮挡 */
+}
+
+/* 顶部和底部的毛玻璃渐变效果 */
+.messages::before,
+.messages::after {
+  content: '';
+  position: sticky;
+  left: 0;
+  right: 0;
+  height: 24px;
+  pointer-events: none;
+  backdrop-filter: blur(6px);
+  z-index: 2;
+}
+
+.messages::before {
+  top: 0;
+  background: linear-gradient(var(--bg-color), transparent);
+}
+
+.messages::after {
+  bottom: 0;
+  background: linear-gradient(transparent, var(--bg-color));
 }
 
 /* 自定义滚动条样式 */
@@ -413,7 +437,7 @@
 
   .messages {
     padding: 20px 0;
-    padding-bottom: 140px;
+    padding-bottom: 100px;
   }
 
   .exampleQueries {


### PR DESCRIPTION
## Summary
- add sticky gradient overlays with blur at the top and bottom of the message list
- tweak scroll padding and reduce bottom space so messages no longer get clipped under the header or appear far from the bottom

## Testing
- `python -m pytest backend/`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686004813ccc8331a8297e3eb0e9060e