### PR TITLE
Fix header overlapping messages

### DIFF
--- a/frontend/moviegpt-react/src/App.tsx
+++ b/frontend/moviegpt-react/src/App.tsx
@@ -27,6 +27,7 @@ const App: React.FC = () => {
     if (stored) return stored === 'dark';
     return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
   });
+  const [isHeaderHidden, setIsHeaderHidden] = useState(false);
 
   useEffect(() => {
     document.body.classList.toggle('dark', isDarkMode);
@@ -44,7 +45,7 @@ const App: React.FC = () => {
     updateOffsets();
     window.addEventListener('resize', updateOffsets);
     return () => window.removeEventListener('resize', updateOffsets);
-  }, [hasStartedConversation, inputValue]);
+  }, [hasStartedConversation, inputValue, isHeaderHidden]);
 
   const toggleDarkMode = useCallback(() => {
     setIsDarkMode(prev => !prev);
@@ -94,6 +95,7 @@ const App: React.FC = () => {
 
     // 标记对话已开始
     setHasStartedConversation(true);
+    setIsHeaderHidden(true);
     // 隐藏欢迎文字
     setShouldHideWelcome(true);
 
@@ -130,6 +132,7 @@ const App: React.FC = () => {
     setIsLoading(false);
     setShouldHideWelcome(false);
     setHasStartedConversation(false);
+    setIsHeaderHidden(false);
     setInputValue('');
     setShowConfirmDialog(false);
     
@@ -165,6 +168,7 @@ const App: React.FC = () => {
         isCompact={hasStartedConversation}
         isDarkMode={isDarkMode}
         onToggleDarkMode={toggleDarkMode}
+        isHidden={isHeaderHidden}
       />
       
       <div className={styles.mainContainer}>

--- a/frontend/moviegpt-react/src/components/Header.tsx
+++ b/frontend/moviegpt-react/src/components/Header.tsx
@@ -5,11 +5,15 @@ interface HeaderProps {
   isCompact: boolean;
   isDarkMode: boolean;
   onToggleDarkMode: () => void;
+  isHidden?: boolean;
 }
 
-const Header = React.forwardRef<HTMLDivElement, HeaderProps>(({ isCompact, isDarkMode, onToggleDarkMode }, ref) => {
+const Header = React.forwardRef<HTMLDivElement, HeaderProps>(({ isCompact, isDarkMode, onToggleDarkMode, isHidden }, ref) => {
   return (
-    <div ref={ref} className={`${styles.header} ${isCompact ? styles.headerCompact : ''}`}>
+    <div
+      ref={ref}
+      className={`${styles.header} ${isCompact ? styles.headerCompact : ''} ${isHidden ? styles.headerHidden : ''}`}
+    >
       <div className={`${styles.logo} ${isCompact ? styles.logoCompact : ''}`}>
         MovieGPT
       </div>

--- a/frontend/moviegpt-react/src/styles/App.module.css
+++ b/frontend/moviegpt-react/src/styles/App.module.css
@@ -23,6 +23,10 @@
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
+.headerHidden {
+  display: none;
+}
+
 .logo {
   font-size: 24px;
   font-weight: 700;


### PR DESCRIPTION
## Summary
- hide the header once a conversation starts
- allow clearing the chat to show the header again
- add CSS for the hidden header state

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68600e7cfd3083319097943ca483f4a1