### PR TITLE
Implement caching & retry for OMDb requests

### DIFF
--- a/backend/get_info.py
+++ b/backend/get_info.py
@@ -1,18 +1,49 @@
-import os
-import requests
+"""Helper for fetching movie details from OMDb with retry and caching."""
+
+from __future__ import annotations
+
 import json
+import os
+import time
+from typing import Dict
+
+import requests
 from dotenv import load_dotenv
 
 load_dotenv()
 OMDB_API_KEY = os.getenv("OMDB_API_KEY")
 
 
-def get_info(id: str):
-    url = f"https://www.omdbapi.com/?i={id}&apikey={OMDB_API_KEY}&plot=full"
-    response = requests.get(url)
-    text = response.text
-    text = json.loads(text)
-    return text
+_CACHE: Dict[str, dict] = {}
+
+
+def _fetch_from_api(imdb_id: str, retries: int = 3) -> dict:
+    """Fetch data from OMDb, retrying on failure."""
+    url = f"https://www.omdbapi.com/?i={imdb_id}&apikey={OMDB_API_KEY}&plot=full"
+    for attempt in range(retries):
+        try:
+            response = requests.get(url, timeout=10)
+            response.raise_for_status()
+            data = response.json()
+            # OMDb uses `Response":"False"` to indicate errors
+            if data.get("Response", "True") == "False":
+                raise ValueError(data.get("Error", "Unknown error"))
+            return data
+        except Exception:
+            if attempt == retries - 1:
+                raise
+            # Exponential backoff
+            time.sleep(2 ** attempt)
+
+
+def get_info(imdb_id: str) -> dict:
+    """Return movie info from cache or fetch from OMDb."""
+    if imdb_id in _CACHE:
+        return _CACHE[imdb_id]
+
+    data = _fetch_from_api(imdb_id)
+    _CACHE[imdb_id] = data
+    return data
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- retry OMDb API requests on failure and cache results in `get_info`

## Testing
- `python -m pytest backend/`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68601c56d11c8331b46040c14c6718d7