### PR TITLE
Improve movie info panels

### DIFF
--- a/frontend/moviegpt-react/src/App.tsx
+++ b/frontend/moviegpt-react/src/App.tsx
@@ -8,6 +8,7 @@ import WelcomeText from './components/WelcomeText';
 import ExampleQueries from './components/ExampleQueries';
 import InputArea from './components/InputArea';
 import SimpleConfirmDialog from './components/SimpleConfirmDialog';
+import MovieInfoPanel from './components/MovieInfoPanel';
 import styles from './styles/App.module.css';
 
 const App: React.FC = () => {
@@ -19,6 +20,7 @@ const App: React.FC = () => {
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
   const [isBackendConnected, setIsBackendConnected] = useState(false);
   const [refreshQueries, setRefreshQueries] = useState(false);
+  const [selectedMovieId, setSelectedMovieId] = useState<string | null>(null);
   const clearButtonRef = useRef<HTMLButtonElement>(null);
   const headerRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -161,6 +163,10 @@ const App: React.FC = () => {
     handleSendMessage(query);
   }, [handleSendMessage]);
 
+  const handleMovieSelect = useCallback((id: string) => {
+    setSelectedMovieId(id);
+  }, []);
+
   return (
     <div className={styles.app}>
       <Header
@@ -173,7 +179,19 @@ const App: React.FC = () => {
       
       <div className={styles.mainContainer}>
         <WelcomeText shouldHide={shouldHideWelcome} />
-        <MessageList messages={messages} isLoading={isLoading} />
+        <MessageList messages={messages} isLoading={isLoading} onMovieSelect={handleMovieSelect} />
+        <MovieInfoPanel
+          imdbId={selectedMovieId}
+          onClose={() => setSelectedMovieId(null)}
+          side="left"
+          variant="poster"
+        />
+        <MovieInfoPanel
+          imdbId={selectedMovieId}
+          onClose={() => setSelectedMovieId(null)}
+          side="right"
+          variant="details"
+        />
       </div>
 
       <div className={styles.bottomFixed} ref={bottomRef}>

--- a/frontend/moviegpt-react/src/components/Message.tsx
+++ b/frontend/moviegpt-react/src/components/Message.tsx
@@ -3,7 +3,6 @@ import ReactMarkdown, { uriTransformer } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Message as MessageType } from '../types';
 import styles from '../styles/Message.module.css';
-import MovieInfoPanel from './MovieInfoPanel';
 
 interface Movie {
   id: string;
@@ -12,12 +11,12 @@ interface Movie {
 
 interface MessageProps {
   message: MessageType;
+  onMovieSelect?: (id: string) => void;
 }
 
-const Message: React.FC<MessageProps> = ({ message }) => {
+const Message: React.FC<MessageProps> = ({ message, onMovieSelect }) => {
   const { type, text, sql, data, results } = message;
   const [isExpanded, setIsExpanded] = useState(false);
-  const [selectedMovie, setSelectedMovie] = useState<Movie | null>(null);
 
   const renderResultData = (d: any): React.ReactNode => {
     if (Array.isArray(d) && d.length > 0 && typeof d[0] === 'object') {
@@ -113,7 +112,7 @@ const Message: React.FC<MessageProps> = ({ message }) => {
                     <button
                       type="button"
                       className={styles.movieLink}
-                      onClick={() => setSelectedMovie({ id, title: String(children) })}
+                      onClick={() => onMovieSelect && onMovieSelect(id)}
                     >
                       {children}
                     </button>
@@ -188,11 +187,6 @@ const Message: React.FC<MessageProps> = ({ message }) => {
           </div>
         )}
       </div>
-      <MovieInfoPanel
-        imdbId={selectedMovie?.id || null}
-        onClose={() => setSelectedMovie(null)}
-        side={type === 'user' ? 'left' : 'right'}
-      />
     </div>
   );
 };

--- a/frontend/moviegpt-react/src/components/MessageList.tsx
+++ b/frontend/moviegpt-react/src/components/MessageList.tsx
@@ -7,9 +7,10 @@ import styles from '../styles/App.module.css';
 interface MessageListProps {
   messages: MessageType[];
   isLoading: boolean;
+  onMovieSelect?: (id: string) => void;
 }
 
-const MessageList: React.FC<MessageListProps> = ({ messages, isLoading }) => {
+const MessageList: React.FC<MessageListProps> = ({ messages, isLoading, onMovieSelect }) => {
   const messagesRef = useRef<HTMLDivElement>(null);
   const scrollTimeoutRef = useRef<NodeJS.Timeout>();
 
@@ -68,11 +69,11 @@ const MessageList: React.FC<MessageListProps> = ({ messages, isLoading }) => {
   return (
     <div ref={messagesRef} className={styles.messages}>
       {messages.map((message) => (
-        <Message key={message.id} message={message} />
+        <Message key={message.id} message={message} onMovieSelect={onMovieSelect} />
       ))}
       {isLoading && <LoadingMessage />}
     </div>
   );
 };
 
-export default MessageList; 
+export default MessageList;

--- a/frontend/moviegpt-react/src/components/MovieInfoPanel.tsx
+++ b/frontend/moviegpt-react/src/components/MovieInfoPanel.tsx
@@ -6,9 +6,10 @@ interface MovieInfoPanelProps {
   imdbId: string | null;
   onClose: () => void;
   side?: 'left' | 'right';
+  variant?: 'poster' | 'details' | 'full';
 }
 
-const MovieInfoPanel: React.FC<MovieInfoPanelProps> = ({ imdbId, onClose, side = 'right' }) => {
+const MovieInfoPanel: React.FC<MovieInfoPanelProps> = ({ imdbId, onClose, side = 'right', variant = 'full' }) => {
   const [info, setInfo] = useState<any | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -37,13 +38,36 @@ const MovieInfoPanel: React.FC<MovieInfoPanelProps> = ({ imdbId, onClose, side =
       <button className={styles.closeButton} onClick={onClose}>&times;</button>
       {info ? (
         <div className={styles.content}>
-          {info.Poster && info.Poster !== 'N/A' && (
+          {variant !== 'details' && info.Poster && info.Poster !== 'N/A' && (
             <img src={info.Poster} alt={info.Title} className={styles.poster} />
           )}
-          <h2 className={styles.title}>
-            {info.Title} ({info.Year})
-          </h2>
-          <p className={styles.plot}>{info.Plot}</p>
+          {variant !== 'details' && (
+            <>
+              <h2 className={styles.title}>
+                {info.Title} ({info.Year})
+              </h2>
+              <p className={styles.plot}>{info.Plot}</p>
+            </>
+          )}
+          {variant !== 'poster' && (
+            <div className={styles.extra}>
+              <p>
+                <strong>导演:</strong> {info.Director}
+              </p>
+              <p>
+                <strong>主演:</strong> {info.Actors}
+              </p>
+              <p>
+                <strong>类型:</strong> {info.Genre}
+              </p>
+              <p>
+                <strong>评分:</strong> {info.imdbRating}
+              </p>
+              <p>
+                <strong>国家:</strong> {info.Country}
+              </p>
+            </div>
+          )}
         </div>
       ) : error ? (
         <div className={styles.loading}>{error}</div>

--- a/frontend/moviegpt-react/src/styles/MovieInfoPanel.module.css
+++ b/frontend/moviegpt-react/src/styles/MovieInfoPanel.module.css
@@ -1,24 +1,28 @@
 .panel {
+  position: absolute;
+  top: 0;
   width: 260px;
   background: var(--bg-color);
   color: var(--text-color);
   border: 1px solid var(--border-color);
   border-radius: 8px;
-  overflow: hidden;
+  overflow-y: auto;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   padding: 16px;
   animation-duration: 0.3s;
   animation-fill-mode: both;
   animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  max-height: 100%;
+  background-clip: padding-box;
 }
 
 .left {
-  margin-right: 8px;
+  right: calc(100% + 8px);
   animation-name: slideInLeft;
 }
 
 .right {
-  margin-left: 8px;
+  left: calc(100% + 8px);
   animation-name: slideInRight;
 }
 
@@ -39,6 +43,12 @@
   margin-bottom: 12px;
 }
 
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 .title {
   font-size: 18px;
   margin-bottom: 8px;
@@ -47,6 +57,11 @@
 .plot {
   font-size: 14px;
   line-height: 1.4;
+}
+
+.extra {
+  font-size: 13px;
+  line-height: 1.5;
 }
 
 .loading {


### PR DESCRIPTION
## Summary
- show movie details on left and right sidebars
- centralize movie selection state in `App`
- support multiple panel variants and absolute positioning

## Testing
- `CI=true npm test --silent -- --passWithNoTests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68601d962c848331ad0e8bb93c40c8f5