### PR TITLE
Fix hidden movie info panel

### DIFF
--- a/frontend/moviegpt-react/src/index.css
+++ b/frontend/moviegpt-react/src/index.css
@@ -51,7 +51,8 @@ body {
               color var(--theme-transition) ease,
               border-color var(--theme-transition) ease;
   height: 100vh;
-  overflow: hidden;
+  overflow-y: hidden;
+  overflow-x: visible;
 }
 
 #root {

--- a/frontend/moviegpt-react/src/styles/App.module.css
+++ b/frontend/moviegpt-react/src/styles/App.module.css
@@ -4,7 +4,7 @@
   height: 100vh;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .header {
@@ -148,7 +148,7 @@
   width: 100%;
   padding: 0 20px;
   position: relative;
-  overflow: hidden;
+  overflow: visible;
   display: flex;
   flex-direction: column;
 }

--- a/frontend/moviegpt-react/src/styles/MovieInfoPanel.module.css
+++ b/frontend/moviegpt-react/src/styles/MovieInfoPanel.module.css
@@ -14,6 +14,8 @@
   animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   max-height: 100%;
   background-clip: padding-box;
+  backdrop-filter: blur(6px);
+  z-index: 20;
 }
 
 .left {
@@ -41,6 +43,7 @@
   width: 100%;
   border-radius: 4px;
   margin-bottom: 12px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
 }
 
 .content {
@@ -50,7 +53,8 @@
 }
 
 .title {
-  font-size: 18px;
+  font-size: 20px;
+  font-weight: 600;
   margin-bottom: 8px;
 }
 
@@ -60,8 +64,16 @@
 }
 
 .extra {
-  font-size: 13px;
+  font-size: 14px;
   line-height: 1.5;
+}
+
+.extra p {
+  margin: 4px 0;
+}
+
+.extra strong {
+  color: var(--secondary-text-color);
 }
 
 .loading {


### PR DESCRIPTION
## Summary
- allow page overflow to show movie info side panels
- ensure main container doesn't clip panels
- style movie info panels with backdrop blur and nicer typography

## Testing
- `npm test --silent`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686024f477088331abd34770931ef580