### PR TITLE
Remove app top bar and improve scrolling

### DIFF
--- a/frontend/moviegpt-react/src/App.tsx
+++ b/frontend/moviegpt-react/src/App.tsx
@@ -165,7 +165,10 @@ const App: React.FC = () => {
 
   return (
     <div className={styles.app}>
-      <div className={styles.topBar} ref={headerRef}>
+      <div
+        className={`${styles.logoWrapper} ${hasStartedConversation ? styles.logoLeft : ''}`}
+        ref={headerRef}
+      >
         <div className={styles.logo}>MovieGPT</div>
         <button className={styles.themeToggle} onClick={toggleDarkMode} title="切换主题">
           <span className={styles.themeIcon}>

--- a/frontend/moviegpt-react/src/styles/App.module.css
+++ b/frontend/moviegpt-react/src/styles/App.module.css
@@ -8,14 +8,19 @@
 }
 
 
-.topBar {
+
+/* 顶部Logo与主题切换容器 */
+.logoWrapper {
   padding: 12px 20px;
   position: relative;
-  background: var(--bg-color);
-  backdrop-filter: blur(10px);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
   flex-shrink: 0;
-  text-align: center;
+}
+
+.logoLeft {
+  justify-content: flex-start;
 }
 
 .logo {
@@ -177,13 +182,17 @@
 }
 
 /* 自定义滚动条样式 */
-/* 隐藏滚动条 */
 .messages::-webkit-scrollbar {
-  display: none;
+  width: 6px;
+}
+
+.messages::-webkit-scrollbar-thumb {
+  background: var(--border-color);
+  border-radius: 3px;
 }
 
 .messages {
-  scrollbar-width: none;
+  scrollbar-width: thin;
 }
 
 .bottomFixed {
@@ -432,7 +441,7 @@
     transform: translateY(-50%);
   }
 
-  .topBar {
+  .logoWrapper {
     padding: 10px 16px;
   }
 


### PR DESCRIPTION
## Summary
- remove the top bar and expose logo/theme toggle in a new `logoWrapper`
- move the logo to the left once a conversation begins
- show scrollbars for the message list

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6860e49fab348331bc97b4fbeb83c3d7