### PR TITLE
Separate logo and theme toggle

### DIFF
--- a/frontend/moviegpt-react/src/App.tsx
+++ b/frontend/moviegpt-react/src/App.tsx
@@ -8,6 +8,8 @@ import ExampleQueries from './components/ExampleQueries';
 import InputArea from './components/InputArea';
 import SimpleConfirmDialog from './components/SimpleConfirmDialog';
 import MovieInfoPanel from './components/MovieInfoPanel';
+import ThemeToggleButton from './components/ThemeToggleButton';
+import Logo from './components/Logo';
 import styles from './styles/App.module.css';
 
 const App: React.FC = () => {
@@ -165,25 +167,9 @@ const App: React.FC = () => {
 
   return (
     <div className={styles.app}>
-      <div
-        className={`${styles.logoWrapper} ${hasStartedConversation ? styles.logoLeft : ''}`}
-        ref={headerRef}
-      >
-        <div className={styles.logo}>MovieGPT</div>
-        <button className={styles.themeToggle} onClick={toggleDarkMode} title="切换主题">
-          <span className={styles.themeIcon}>
-            {isDarkMode ? (
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <circle cx="12" cy="12" r="5" />
-                <path d="M12 1v2m0 18v2M4.22 4.22l1.42 1.42m12.72 12.72l1.42 1.42M1 12h2m18 0h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
-              </svg>
-            ) : (
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-              </svg>
-            )}
-          </span>
-        </button>
+      <div className={styles.header} ref={headerRef}>
+        <Logo moveLeft={hasStartedConversation} />
+        <ThemeToggleButton isDark={isDarkMode} onToggle={toggleDarkMode} />
       </div>
       
       <div className={styles.mainContainer}>

--- a/frontend/moviegpt-react/src/components/Logo.tsx
+++ b/frontend/moviegpt-react/src/components/Logo.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import styles from '../styles/App.module.css';
+
+interface LogoProps {
+  moveLeft: boolean;
+}
+
+const Logo: React.FC<LogoProps> = ({ moveLeft }) => (
+  <div className={`${styles.logo} ${moveLeft ? styles.logoLeft : ''}`}>MovieGPT</div>
+);
+
+export default Logo;

--- a/frontend/moviegpt-react/src/components/ThemeToggleButton.tsx
+++ b/frontend/moviegpt-react/src/components/ThemeToggleButton.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import styles from '../styles/App.module.css';
+
+interface ThemeToggleButtonProps {
+  isDark: boolean;
+  onToggle: () => void;
+}
+
+const ThemeToggleButton: React.FC<ThemeToggleButtonProps> = ({ isDark, onToggle }) => (
+  <button className={styles.themeToggle} onClick={onToggle} title="切换主题">
+    <span className={styles.themeIcon}>
+      {isDark ? (
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <circle cx="12" cy="12" r="5" />
+          <path d="M12 1v2m0 18v2M4.22 4.22l1.42 1.42m12.72 12.72l1.42 1.42M1 12h2m18 0h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
+        </svg>
+      ) : (
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        </svg>
+      )}
+    </span>
+  </button>
+);
+
+export default ThemeToggleButton;

--- a/frontend/moviegpt-react/src/styles/App.module.css
+++ b/frontend/moviegpt-react/src/styles/App.module.css
@@ -9,8 +9,8 @@
 
 
 
-/* 顶部Logo与主题切换容器 */
-.logoWrapper {
+/* 顶部区域 */
+.header {
   padding: 12px 20px;
   position: relative;
   display: flex;
@@ -19,17 +19,23 @@
   flex-shrink: 0;
 }
 
-.logoLeft {
-  justify-content: flex-start;
-}
-
 .logo {
   font-size: 24px;
   font-weight: 700;
   color: var(--text-color);
   margin-bottom: 4px;
-  transition: all var(--theme-transition) cubic-bezier(0.4, 0, 0.2, 1);
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  transition: left var(--theme-transition) cubic-bezier(0.4, 0, 0.2, 1),
+    transform var(--theme-transition) cubic-bezier(0.4, 0, 0.2, 1);
 }
+
+.logoLeft {
+  left: 0;
+  transform: translateX(0);
+}
+
 
 
 
@@ -441,7 +447,7 @@
     transform: translateY(-50%);
   }
 
-  .logoWrapper {
+  .header {
     padding: 10px 16px;
   }
 


### PR DESCRIPTION
## Summary
- split the logo and theme toggle button into distinct components
- add sliding animation so the logo moves from center to left after chat starts

## Testing
- `npm test -- -u` *(fails: react-scripts not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6860ee91ec648331900d492fd2e5a6d4